### PR TITLE
Fix: test runner stabilization

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
   "license": "MIT",
   "packageManager": "pnpm@10.18.1",
   "scripts": {
-  "dev": "NODE_ENV=development tsx server/index.ts",
-  "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
-  "start": "NODE_ENV=production node dist/index.js",
-  "check": "tsc",
-  "test": "echo \"(no test suite yet)\" && exit 0",
-  "lint": "echo \"(no lint yet)\" && exit 0"
-},
+    "dev": "NODE_ENV=development tsx server/index.ts",
+    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "start": "NODE_ENV=production node dist/index.js",
+    "check": "tsc",
+    "test": "node scripts/run-tests.mjs",
+    "lint": "echo \"(no lint yet)\" && exit 0"
+  },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
     "@jridgewell/trace-mapping": "^0.3.25",

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/smoke",
+  timeout: 15_000,
+  reporter: [["list"]],
+  use: {
+    headless: true,
+  },
+});

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,0 +1,19 @@
+import { spawn } from "node:child_process";
+
+const forwardedArgs = process.argv.slice(2).filter((arg) => arg !== "--run");
+
+const command = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+
+const child = spawn(command, [
+  "exec",
+  "playwright",
+  "test",
+  "--config=playwright.smoke.config.ts",
+  ...forwardedArgs,
+], {
+  stdio: "inherit",
+});
+
+child.on("close", (code) => {
+  process.exit(code ?? 1);
+});

--- a/tests/smoke/test-runner.spec.ts
+++ b/tests/smoke/test-runner.spec.ts
@@ -1,0 +1,7 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("test runner", () => {
+  test("is wired for CI", async () => {
+    expect(true).toBeTruthy();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
-  "include": ["client/src/**/*", "shared/**/*", "server/**/*"],
-  "exclude": ["node_modules", "build", "dist", "**/*.test.ts"],
+  "include": ["client/src", "shared", "server", "tests"],
+  "exclude": ["node_modules", "build", "dist"],
   "compilerOptions": {
     "incremental": true,
     "tsBuildInfoFile": "./node_modules/typescript/tsbuildinfo",


### PR DESCRIPTION
## Summary
- add a smoke-level Playwright configuration and stub test that verify the runner wiring
- wire a Node-based helper so `pnpm run test -- --run` delegates to the smoke suite and extend tsconfig coverage to the tests folder

## Testing
- pnpm run test -- --run *(fails: pnpm 10.18.1 download blocked in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e54482776c8329a001ab47b1dc01e6