### PR TITLE
style(ui): homepage and brand polish

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,6 +3,18 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
+    <title>TEAIM — AI in Your Team. Power in Your Project.</title>
+    <meta
+      name="description"
+      content="TEAIM is the AI-powered project management operating system that brings AI teammates into your delivery rituals."
+    />
+    <meta property="og:title" content="TEAIM — AI in Your Team. Power in Your Project." />
+    <meta
+      property="og:description"
+      content="Private beta for enterprise teams who want AI copilots coordinating meetings, docs, and delivery."
+    />
+    <meta name="theme-color" content="#F6F7FF" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0E0F12" media="(prefers-color-scheme: dark)" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Architects+Daughter&family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=Fira+Code:wght@300..700&family=Geist+Mono:wght@100..900&family=Geist:wght@100..900&family=IBM+Plex+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&family=IBM+Plex+Sans:ital,wght@0,100..700;1,100..700&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&family=Lora:ital,wght@0,400..700;1,400..700&family=Merriweather:ital,opsz,wght@0,18..144,300..900;1,18..144,300..900&family=Montserrat:ital,wght@0,100..900;1,100..900&family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Outfit:wght@100..900&family=Oxanium:wght@200..800&family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto+Mono:ital,wght@0,100..700;1,100..700&family=Roboto:ital,wght@0,100..900;1,100..900&family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&family=Source+Serif+4:ital,opsz,wght@0,8..60,200..900;1,8..60,200..900&family=Space+Grotesk:wght@300..700&family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -58,7 +58,7 @@
 
 :root {
   /* Brand (from TEAIM Brand Book v2) */
-  --brand-charcoal: #1C1C1E;
+  --brand-charcoal: #12131a;
   --brand-orange:   #F26B1D; /* AI accent */
   --brand-gold:     #FFC933;
   --brand-success:  #2ECC71;
@@ -66,37 +66,39 @@
   --brand-error:    #E74C3C;
   --brand-white:    #FFFFFF;
   --brand-midgray:  #7D7D7D; /* for light themes / borders only on dark */
+  --brand-purple:   #6C4CFF;
+  --brand-neon:     #7CFBD6;
 
-  /* Dark UI surfaces (accessible) */
-  --ui-bg:        #0E0F12;             /* main app background (deeper than charcoal for contrast) */
-  --ui-panel:     #14161D;             /* card surface */
-  --ui-panel-2:   #191C26;             /* elevated surface */
-  --ui-border:    #2C2F3A;             /* visible border on dark */
-  --ui-divider:   #252832;
+  /* Light UI surfaces tuned to brand palette */
+  --ui-bg:        #F6F7FF;
+  --ui-panel:     #FFFFFF;
+  --ui-panel-2:   #EEF0FF;
+  --ui-border:    rgba(21, 20, 35, 0.12);
+  --ui-divider:   rgba(21, 20, 35, 0.14);
 
-  /* Text (accessible on dark) */
-  --text-strong:  #FFFFFF;             /* primary headings */
-  --text:         #E9ECF1;             /* body text */
-  --text-soft:    #C7CCD7;             /* secondary */
-  --text-muted:   #A7ADBD;             /* tertiary */
-  --text-dim:     #8C93A3;             /* placeholders only */
+  /* Text (accessible on light) */
+  --text-strong:  #0F1016;
+  --text:         rgba(17, 19, 30, 0.88);
+  --text-soft:    rgba(17, 19, 30, 0.72);
+  --text-muted:   rgba(17, 19, 30, 0.58);
+  --text-dim:     rgba(17, 19, 30, 0.45);
 
   /* Action & state */
-  --accent:       var(--brand-orange);  /* primary CTAs, highlights */
-  --accent-2:     var(--brand-gold);    /* secondary highlight */
+  --accent:       var(--brand-purple);
+  --accent-2:     var(--brand-neon);
   --success:      var(--brand-success);
   --warn:         var(--brand-warn);
   --error:        var(--brand-error);
 
-  /* Pills / badges backgrounds (transparent tints for dark) */
-  --pill-accent:  rgba(242,107,29,0.18);
-  --pill-gold:    rgba(255,201,51,0.18);
-  --pill-success: rgba(46,204,113,0.18);
-  --pill-warn:    rgba(255,193,7,0.18);
-  --pill-error:   rgba(231,76,60,0.18);
+  /* Pills / badges backgrounds */
+  --pill-accent:  rgba(108, 76, 255, 0.12);
+  --pill-gold:    rgba(255, 201, 51, 0.18);
+  --pill-success: rgba(46, 204, 113, 0.18);
+  --pill-warn:    rgba(255, 193, 7, 0.18);
+  --pill-error:   rgba(231, 76, 60, 0.18);
 
   /* Focus outline for keyboard nav */
-  --focus:        rgba(255,201,51,0.65);
+  --focus:        rgba(124, 251, 214, 0.65);
 
   /* Legacy mappings for existing code */
   --background: var(--ui-bg);
@@ -105,20 +107,20 @@
   --card-foreground: var(--text);
   --popover: var(--ui-panel-2);
   --popover-foreground: var(--text);
-  --primary: var(--brand-orange);              /* Primary actions = orange */
-  --primary-foreground: var(--ui-bg);
+  --primary: var(--brand-purple);
+  --primary-foreground: var(--brand-white);
   --secondary: var(--ui-panel-2);
   --secondary-foreground: var(--text);
   --muted: var(--ui-panel-2);
   --muted-foreground: var(--text-muted);
   --accent-foreground: var(--text-strong);
   --destructive: var(--error);
-  --destructive-foreground: var(--text-strong);
+  --destructive-foreground: var(--brand-white);
   --border: var(--ui-border);
   --input: var(--ui-panel-2);
-  --ring: var(--ui-border);
-  --success: var(--brand-success);             /* Success = green */
-  --chart-1: hsl(220, 70%, 50%);
+  --ring: color-mix(in oklab, var(--brand-purple), transparent 70%);
+  --success: var(--brand-success);
+  --chart-1: hsl(259, 88%, 66%);
   --chart-2: hsl(160, 60%, 45%);
   --chart-3: hsl(30, 80%, 55%);
   --chart-4: hsl(280, 65%, 60%);
@@ -136,32 +138,263 @@
 }
 
 .dark {
-  /* Use same TEAIM brand colors as :root for consistent dark theme */
-  --background: var(--ui-bg);
-  --foreground: var(--text);
-  --card: var(--ui-panel);
-  --card-foreground: var(--text);
-  --popover: var(--ui-panel-2);
-  --popover-foreground: var(--text);
-  --primary: var(--brand-orange);              /* Primary actions = orange */
-  --primary-foreground: var(--ui-bg);
-  --secondary: var(--ui-panel-2);
-  --secondary-foreground: var(--text);
-  --muted: var(--ui-panel-2);
-  --muted-foreground: var(--text-muted);
-  --accent: var(--brand-orange);
-  --accent-foreground: var(--text-strong);
+  /* Dark theme variant anchored in charcoal + neon palette */
+  --background: #0E0F12;
+  --foreground: #E9ECF1;
+  --card: #14161D;
+  --card-foreground: #E9ECF1;
+  --popover: #191C26;
+  --popover-foreground: #E9ECF1;
+  --primary: var(--brand-orange);
+  --primary-foreground: #0B0C12;
+  --secondary: #191C26;
+  --secondary-foreground: #E9ECF1;
+  --muted: #191C26;
+  --muted-foreground: #A7ADBD;
+  --accent: var(--brand-purple);
+  --accent-foreground: var(--brand-white);
   --destructive: var(--error);
-  --destructive-foreground: var(--text-strong);
-  --border: var(--ui-border);
-  --input: var(--ui-panel-2);
-  --ring: var(--ui-border);
-  --success: var(--brand-success);             /* Success = green */
-  --chart-1: hsl(220, 70%, 50%);
+  --destructive-foreground: var(--brand-white);
+  --border: #2C2F3A;
+  --input: #191C26;
+  --ring: color-mix(in oklab, var(--brand-purple), transparent 60%);
+  --success: var(--brand-success);
+  --chart-1: hsl(259, 82%, 72%);
   --chart-2: hsl(160, 60%, 45%);
   --chart-3: hsl(30, 80%, 55%);
   --chart-4: hsl(280, 65%, 60%);
   --chart-5: hsl(340, 75%, 55%);
+}
+
+.dark {
+  --ui-bg:        #0E0F12;
+  --ui-panel:     #14161D;
+  --ui-panel-2:   #191C26;
+  --ui-border:    #2C2F3A;
+  --ui-divider:   #252832;
+  --text-strong:  #FFFFFF;
+  --text:         #E9ECF1;
+  --text-soft:    #C7CCD7;
+  --text-muted:   #A7ADBD;
+  --text-dim:     #8C93A3;
+}
+
+.dark body {
+  background: var(--background);
+  color: var(--foreground);
+}
+
+/* Hero + auth gradients */
+.teaim-hero {
+  background:
+    radial-gradient(120% 120% at 0% 0%, rgba(108, 76, 255, 0.18) 0%, transparent 60%),
+    radial-gradient(110% 110% at 100% 20%, rgba(124, 251, 214, 0.16) 0%, transparent 58%),
+    linear-gradient(135deg, rgba(246, 247, 255, 0.98) 0%, rgba(233, 232, 255, 0.92) 55%, rgba(255, 255, 255, 0.95) 100%);
+}
+
+.dark .teaim-hero {
+  background:
+    radial-gradient(140% 140% at 0% 0%, rgba(108, 76, 255, 0.28) 0%, transparent 60%),
+    radial-gradient(120% 120% at 100% 20%, rgba(124, 251, 214, 0.18) 0%, transparent 60%),
+    linear-gradient(135deg, rgba(14, 15, 18, 0.95) 0%, rgba(24, 18, 38, 0.95) 45%, rgba(16, 17, 28, 0.98) 100%);
+}
+
+.teaim-auth-bg {
+  background:
+    radial-gradient(90% 120% at 15% 15%, rgba(108, 76, 255, 0.22) 0%, transparent 70%),
+    radial-gradient(70% 110% at 85% 0%, rgba(124, 251, 214, 0.18) 0%, transparent 75%),
+    linear-gradient(160deg, rgba(246, 247, 255, 1) 0%, rgba(231, 236, 255, 0.92) 50%, rgba(244, 248, 255, 0.95) 100%);
+}
+
+.dark .teaim-auth-bg {
+  background:
+    radial-gradient(100% 130% at 0% 0%, rgba(108, 76, 255, 0.3) 0%, transparent 70%),
+    radial-gradient(80% 120% at 100% 0%, rgba(124, 251, 214, 0.24) 0%, transparent 70%),
+    linear-gradient(160deg, rgba(8, 9, 14, 0.98) 0%, rgba(16, 15, 28, 0.98) 50%, rgba(18, 20, 32, 0.98) 100%);
+}
+
+.teaim-grid-pattern {
+  position: absolute;
+  inset: 0;
+  opacity: 0.18;
+  background-image: linear-gradient(90deg, rgba(124, 251, 214, 0.12) 1px, transparent 0),
+    linear-gradient(0deg, rgba(108, 76, 255, 0.12) 1px, transparent 0);
+  background-size: 32px 32px;
+  mask: radial-gradient(circle at center, rgba(0, 0, 0, 0.55) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+.dark .teaim-grid-pattern {
+  opacity: 0.22;
+}
+
+.teaim-surface {
+  background: color-mix(in srgb, var(--card) 86%, rgba(124, 251, 214, 0.08));
+  border: 1px solid color-mix(in srgb, var(--border) 80%, rgba(108, 76, 255, 0.14));
+  box-shadow: 0 24px 60px -40px rgba(12, 14, 33, 0.65);
+  backdrop-filter: blur(18px) saturate(140%);
+}
+
+.dark .teaim-surface {
+  background: color-mix(in srgb, var(--card) 88%, rgba(16, 18, 40, 0.65));
+  border-color: color-mix(in srgb, var(--border) 60%, rgba(124, 251, 214, 0.18));
+  box-shadow: 0 28px 72px -44px rgba(2, 5, 15, 0.95);
+}
+
+.teaim-nav {
+  background: color-mix(in srgb, var(--background) 80%, rgba(124, 251, 214, 0.06));
+  backdrop-filter: blur(18px) saturate(140%);
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 70%, rgba(108, 76, 255, 0.18));
+}
+
+.dark .teaim-nav {
+  background: color-mix(in srgb, var(--ui-bg) 88%, rgba(14, 16, 33, 0.6));
+  border-bottom-color: color-mix(in srgb, var(--ui-border) 70%, rgba(108, 76, 255, 0.2));
+}
+
+.teaim-footer {
+  background: linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--ui-panel-2) 70%, rgba(108, 76, 255, 0.08)) 100%);
+}
+
+.teaim-input {
+  border-radius: 18px;
+  border: 1px solid color-mix(in srgb, var(--border) 70%, rgba(108, 76, 255, 0.15));
+  background: color-mix(in srgb, var(--card) 92%, rgba(124, 251, 214, 0.04));
+  padding: 0.9rem 1rem;
+  color: var(--foreground);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.12s ease;
+}
+
+.teaim-input:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--brand-purple) 70%, var(--brand-neon) 30%);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--brand-purple) 25%, transparent 70%);
+}
+
+.teaim-cta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  padding: 0.9rem 1.8rem;
+  font-weight: 600;
+  background-image: linear-gradient(135deg, var(--brand-purple) 0%, var(--brand-orange) 50%, var(--brand-neon) 100%);
+  color: #05060C;
+  box-shadow: 0 20px 40px -22px rgba(108, 76, 255, 0.55);
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.teaim-cta:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 26px 50px -20px rgba(108, 76, 255, 0.55);
+}
+
+.teaim-cta:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--brand-neon) 40%, transparent 60%);
+}
+
+.teaim-cta-ghost {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  padding: 0.9rem 1.8rem;
+  font-weight: 600;
+  border: 1px solid color-mix(in srgb, var(--border) 70%, rgba(108, 76, 255, 0.25));
+  color: var(--foreground);
+  background: color-mix(in srgb, var(--card) 90%, transparent);
+  transition: border-color 0.15s ease, background 0.2s ease, transform 0.15s ease;
+}
+
+.teaim-cta-ghost:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--brand-purple) 45%, var(--brand-neon) 55%);
+  background: color-mix(in srgb, var(--card) 80%, rgba(124, 251, 214, 0.08));
+}
+
+.teaim-cta-ghost:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--brand-purple) 25%, transparent 70%);
+}
+
+.teaim-toggle {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.35rem;
+  padding: 0.35rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--card) 92%, rgba(108, 76, 255, 0.08));
+  border: 1px solid color-mix(in srgb, var(--border) 70%, rgba(124, 251, 214, 0.16));
+}
+
+.teaim-toggle button {
+  border-radius: 999px;
+  font-weight: 600;
+  padding: 0.65rem 1rem;
+  color: var(--text-soft);
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.teaim-toggle button[data-active="true"] {
+  background: linear-gradient(135deg, var(--brand-purple) 0%, color-mix(in srgb, var(--brand-orange) 70%, var(--brand-purple) 30%) 100%);
+  color: var(--brand-white);
+  box-shadow: 0 16px 32px -18px rgba(108, 76, 255, 0.55);
+}
+
+.teaim-toggle button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--brand-neon) 30%, transparent 70%);
+}
+
+@keyframes teaimFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes teaimFadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.teaim-fade-in {
+  opacity: 0;
+  animation: teaimFadeIn 0.7s ease forwards;
+}
+
+.teaim-fade-in-up {
+  opacity: 0;
+  animation: teaimFadeInUp 0.8s ease forwards;
+}
+
+.teaim-delay-150 {
+  animation-delay: 0.15s;
+}
+
+.teaim-delay-300 {
+  animation-delay: 0.3s;
+}
+
+.teaim-delay-450 {
+  animation-delay: 0.45s;
+}
+
+.teaim-delay-600 {
+  animation-delay: 0.6s;
 }
 
 @layer base {

--- a/client/src/pages/LandingPage.tsx
+++ b/client/src/pages/LandingPage.tsx
@@ -45,34 +45,33 @@ export default function LandingPage() {
   return (
     <div className="min-h-screen bg-background text-foreground">
       <PublicNav authed={authed} nextLink={nextLink} />
-      <main>
+      <main className="relative overflow-hidden">
         {/* Hero Section */}
-        <section id="hero" className="relative bg-background text-foreground">
-          <div className="mx-auto max-w-5xl px-6 py-24 text-center">
-            {/* Logo placeholder - replace with actual logo path when available */}
-            <div className="mx-auto h-14 mb-8 flex items-center justify-center">
-              <div className="text-3xl font-bold text-brand-orange">TEAIM</div>
-            </div>
-            <h1 className="text-5xl font-extrabold leading-tight" data-testid="heading-landing">
-              The <span className="emph">AI-powered Project Management Operating System</span>
-            </h1>
-            <p className="mt-6 text-lg text-muted-foreground max-w-2xl mx-auto">
-              TEAIM learns from meetings, docs, and decisions to automate actions, flag risks, and deliver projects with precision. 
-              We're inviting only a <span className="emph">select handful of teams</span> into our private beta.
-            </p>
-            <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
-              <a 
-                href="#beta" 
-                className="px-6 py-3 rounded-xl bg-brand-orange text-black font-semibold hover:opacity-90"
-                data-testid="link-request-beta"
+        <section id="hero" className="relative teaim-hero text-foreground">
+          <div className="teaim-grid-pattern" aria-hidden />
+          <div className="relative mx-auto flex min-h-[calc(100vh-4rem)] w-full max-w-5xl flex-col items-center justify-center gap-8 px-6 py-24 text-center">
+            <img
+              src="/teaim-logo.svg"
+              alt="TEAIM logo"
+              className="h-16 w-auto teaim-fade-in drop-shadow-xl"
+            />
+            <div className="space-y-6">
+              <h1
+                className="text-balance text-4xl font-extrabold leading-tight text-[var(--text-strong)] sm:text-5xl lg:text-6xl teaim-fade-in-up teaim-delay-150"
+                data-testid="heading-landing"
               >
+                TEAIM — AI in Your Team. Power in Your Project.
+              </h1>
+              <p className="mx-auto max-w-2xl text-lg text-muted-foreground teaim-fade-in-up teaim-delay-300">
+                A project management operating system that listens to meetings, reads the docs, and automates delivery with neon-fast accountability.
+                We’re inviting a <span className="font-semibold text-[var(--accent)]">small cohort of enterprise teams</span> into our private beta.
+              </p>
+            </div>
+            <div className="mt-2 flex w-full flex-col items-center justify-center gap-4 sm:flex-row teaim-fade-in-up teaim-delay-450">
+              <a href="#beta" className="teaim-cta w-full sm:w-auto" data-testid="link-request-beta">
                 Request Beta Access
               </a>
-              <a 
-                href="#contact" 
-                className="px-6 py-3 rounded-xl border border-border hover:bg-accent"
-                data-testid="link-talk-to-us"
-              >
+              <a href="#contact" className="teaim-cta-ghost w-full sm:w-auto" data-testid="link-talk-to-us">
                 Talk to Us
               </a>
             </div>
@@ -80,25 +79,28 @@ export default function LandingPage() {
         </section>
 
         {/* Three Value Props */}
-        <section className="bg-accent/30 py-20">
-          <div className="mx-auto max-w-5xl px-6 grid md:grid-cols-3 gap-8 text-center">
-            <div data-testid="value-prop-automated">
+        <section
+          className="py-20"
+          style={{ background: "color-mix(in srgb, var(--card) 92%, rgba(108, 76, 255, 0.06))" }}
+        >
+          <div className="mx-auto grid max-w-5xl gap-8 px-6 text-center md:grid-cols-3">
+            <div className="teaim-fade-in-up teaim-delay-150" data-testid="value-prop-automated">
               <div className="flex justify-center mb-3">
-                <Zap className="h-8 w-8 text-brand-orange" />
+                <Zap className="h-8 w-8 text-[var(--accent)]" />
               </div>
               <h3 className="text-xl font-semibold">Semi-Automated Delivery</h3>
               <p className="mt-3 text-muted-foreground">TEAIM converts meeting noise into actions, docs into scripts, and timelines into forecasts.</p>
             </div>
-            <div data-testid="value-prop-predictive">
+            <div className="teaim-fade-in-up teaim-delay-300" data-testid="value-prop-predictive">
               <div className="flex justify-center mb-3">
-                <Brain className="h-8 w-8 text-brand-orange" />
+                <Brain className="h-8 w-8 text-[var(--accent)]" />
               </div>
               <h3 className="text-xl font-semibold">Predictive Intelligence</h3>
               <p className="mt-3 text-muted-foreground">AI surfaces risks and dependencies before they derail your project.</p>
             </div>
-            <div data-testid="value-prop-enterprise">
+            <div className="teaim-fade-in-up teaim-delay-450" data-testid="value-prop-enterprise">
               <div className="flex justify-center mb-3">
-                <Building2 className="h-8 w-8 text-brand-orange" />
+                <Building2 className="h-8 w-8 text-[var(--accent)]" />
               </div>
               <h3 className="text-xl font-semibold">Enterprise-Ready</h3>
               <p className="mt-3 text-muted-foreground">Governance, sign-offs, and reporting designed for Workday today and SaaS tomorrow.</p>
@@ -109,66 +111,70 @@ export default function LandingPage() {
         {/* Beta CTA */}
         <section id="beta" className="py-20 bg-background">
           <div className="mx-auto max-w-2xl px-6 text-center">
-            <h2 className="text-3xl font-bold">Limited Private Beta</h2>
-            <p className="mt-4 text-lg text-muted-foreground">
-              Join our <span className="emph">invite-only early access</span> program and help shape the future of AI-powered project management.
+            <h2 className="text-3xl font-bold teaim-fade-in-up">Limited Private Beta</h2>
+            <p className="mt-4 text-lg text-muted-foreground teaim-fade-in-up teaim-delay-150">
+              Join our <span className="font-semibold text-[var(--accent)]">invite-only early access</span> program and help shape the future of AI-powered project management.
             </p>
-            <div className="mt-8">
-              <a 
-                href={nextLink} 
-                className="inline-block px-8 py-4 rounded-xl bg-brand-orange text-black font-semibold hover:opacity-90 text-lg"
+            <div className="mt-8 teaim-fade-in-up teaim-delay-300">
+              <a
+                href={nextLink}
+                className="teaim-cta w-full justify-center text-base sm:w-auto"
                 data-testid="link-get-started"
               >
                 {authed ? "Open App" : "Get Started"}
               </a>
             </div>
-            <p className="mt-4 text-sm text-muted-foreground">No fluff. Real project outcomes in week 1.</p>
+            <p className="mt-4 text-sm text-muted-foreground teaim-fade-in-up teaim-delay-450">No fluff. Real project outcomes in week 1.</p>
           </div>
         </section>
 
         {/* Contact Form */}
-        <section id="contact" className="py-20 bg-accent/30">
+        <section
+          id="contact"
+          className="py-20"
+          style={{ background: "color-mix(in srgb, var(--card) 92%, rgba(124, 251, 214, 0.08))" }}
+        >
           <div className="mx-auto max-w-xl px-6 text-center">
-            <h2 className="text-2xl font-bold">Let's talk</h2>
-            <p className="mt-2 text-muted-foreground">Interested but not ready for beta? Leave your info and we'll keep you updated.</p>
-            <form onSubmit={handleSubmit} className="mt-6 space-y-4">
-              <input 
-                type="text" 
-                placeholder="Your Name" 
+            <h2 className="text-2xl font-bold teaim-fade-in-up">Let's talk</h2>
+            <p className="mt-2 text-muted-foreground teaim-fade-in-up teaim-delay-150">Interested but not ready for beta? Leave your info and we'll keep you updated.</p>
+            <form onSubmit={handleSubmit} className="mt-6 space-y-4 teaim-fade-in-up teaim-delay-300">
+              <input
+                type="text"
+                placeholder="Your Name"
                 value={formData.name}
                 onChange={(e) => setFormData({ ...formData, name: e.target.value })}
                 required
-                className="w-full rounded-lg border border-border bg-background px-4 py-3"
+                className="teaim-input w-full"
                 data-testid="input-contact-name"
               />
-              <input 
-                type="email" 
-                placeholder="Work Email" 
+              <input
+                type="email"
+                placeholder="Work Email"
                 value={formData.email}
                 onChange={(e) => setFormData({ ...formData, email: e.target.value })}
                 required
-                className="w-full rounded-lg border border-border bg-background px-4 py-3"
+                className="teaim-input w-full"
                 data-testid="input-contact-email"
               />
-              <textarea 
-                placeholder="Your Message" 
+              <textarea
+                placeholder="Your Message"
                 rows={3}
                 value={formData.message}
                 onChange={(e) => setFormData({ ...formData, message: e.target.value })}
-                className="w-full rounded-lg border border-border bg-background px-4 py-3"
+                className="teaim-input w-full"
                 data-testid="textarea-contact-message"
               />
-              <button 
-                type="submit" 
+              <button
+                type="submit"
                 disabled={submitting || submitted}
-                className="w-full px-6 py-3 rounded-xl bg-brand-orange text-black font-semibold hover:opacity-90 disabled:opacity-50"
+                className="teaim-cta w-full disabled:opacity-50"
                 data-testid="button-contact-submit"
               >
                 {submitting ? "Submitting..." : submitted ? "Submitted!" : "Submit"}
               </button>
             </form>
             {submitted && (
-              <p className="mt-3 text-sm text-green-600 dark:text-green-400">Thank you! We'll be in touch soon.</p>
+              <p className="mt-3 text-sm text-green-600 dark:text-green-400 teaim-fade-in">Thank you! We'll be in touch soon.</p>
             )}
           </div>
         </section>
@@ -180,17 +186,21 @@ export default function LandingPage() {
 
 function PublicNav({ authed, nextLink }: { authed: boolean; nextLink: string }) {
   return (
-    <header className="border-b border-border bg-background/95 backdrop-blur sticky top-0 z-40">
-      <div className="max-w-6xl mx-auto px-6 h-14 flex items-center justify-between">
-        {/* Logo placeholder - replace with actual horizontal logo when available */}
-        <a href="/" className="font-bold text-xl" data-testid="link-logo">
-          <span className="text-brand-orange">TEAIM</span>.app
+    <header className="teaim-nav sticky top-0 z-40 border-b">
+      <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
+        <a href="/" className="flex items-center gap-3" data-testid="link-logo">
+          <img src="/teaim-logo.svg" alt="TEAIM" className="h-9 w-auto drop-shadow" />
+          <span className="hidden text-lg font-semibold tracking-wide text-[var(--text-strong)] sm:inline">TEAIM.app</span>
         </a>
         <nav className="flex items-center gap-4 text-sm">
           <a className="opacity-80 hover:opacity-100" href="#beta" data-testid="link-nav-beta">Beta</a>
           <a className="opacity-80 hover:opacity-100" href="#contact" data-testid="link-nav-contact">Contact</a>
           {authed && <a className="opacity-80 hover:opacity-100" href={nextLink} data-testid="link-nav-open-app">Open App</a>}
-          <a href={authed ? nextLink : "/login"} className="px-3 py-1.5 rounded-xl border border-border hover:bg-accent" data-testid="button-nav-signin">
+          <a
+            href={authed ? nextLink : "/login"}
+            className="teaim-cta-ghost text-sm"
+            data-testid="button-nav-signin"
+          >
             {authed ? "Open App" : "Sign in"}
           </a>
         </nav>
@@ -201,17 +211,28 @@ function PublicNav({ authed, nextLink }: { authed: boolean; nextLink: string }) 
 
 function PublicFooter() {
   return (
-    <footer className="border-t border-border py-8 text-center text-sm text-muted-foreground">
-      <div className="mb-4 flex justify-center">
-        {/* Icon logo placeholder - replace with actual icon logo when available */}
-        <div className="h-8 w-8 rounded bg-brand-orange flex items-center justify-center text-black font-bold">
-          T
-        </div>
+    <footer className="teaim-footer border-t border-border py-10 text-center text-sm text-muted-foreground">
+      <div className="mb-5 flex justify-center">
+        <img src="/teaim-logo.svg" alt="TEAIM mark" className="h-10 w-auto drop-shadow" />
       </div>
-      <p>© {new Date().getFullYear()} TEAIM.app — The AI-powered PMOS</p>
-      <div className="mt-2 space-x-4">
-        <a href="https://www.linkedin.com/company/teaim-app" target="_blank" rel="noopener noreferrer" className="hover:text-foreground" data-testid="link-linkedin">LinkedIn</a>
-        <a href="mailto:info@teaim.app" className="hover:text-foreground" data-testid="link-email">info@teaim.app</a>
+      <p className="text-[var(--text-soft)]">© {new Date().getFullYear()} TEAIM.app — The AI-powered PMOS</p>
+      <div className="mt-3 flex items-center justify-center gap-6 text-sm">
+        <a
+          href="https://www.linkedin.com/company/teaim-app"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="transition hover:text-[var(--accent)]"
+          data-testid="link-linkedin"
+        >
+          LinkedIn
+        </a>
+        <a
+          href="mailto:info@teaim.app"
+          className="transition hover:text-[var(--accent)]"
+          data-testid="link-email"
+        >
+          info@teaim.app
+        </a>
       </div>
     </footer>
   );

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -51,66 +51,79 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen grid place-items-center bg-slate-950 text-slate-100">
-      <div className="w-full max-w-md p-8 rounded-2xl border border-slate-800 bg-slate-900/50 space-y-4">
-        <div className="text-center">
-          <a href="/" className="font-bold text-xl" data-testid="link-logo">TEAIM.app</a>
-          <div className="text-sm opacity-70">Sign in to your workspace</div>
-        </div>
+    <div className="relative min-h-screen teaim-auth-bg text-foreground">
+      <div className="teaim-grid-pattern" aria-hidden />
+      <div className="relative z-10 flex min-h-screen items-center justify-center px-6 py-16">
+        <div className="teaim-surface w-full max-w-md space-y-6 rounded-3xl p-10 shadow-2xl teaim-fade-in-up">
+          <div className="text-center space-y-3">
+            <a href="/" className="inline-flex flex-col items-center gap-2" data-testid="link-logo">
+              <img src="/teaim-logo.svg" alt="TEAIM" className="h-12 w-auto drop-shadow" />
+              <span className="text-lg font-semibold tracking-wide text-[var(--text-strong)]">TEAIM.app</span>
+            </a>
+            <p className="text-sm text-muted-foreground">Sign in to your workspace</p>
+          </div>
 
-        <div className="grid grid-cols-2 gap-2">
-          <button
-            className={`px-3 py-2 rounded-xl border ${mode === "signin" ? "bg-slate-800 border-slate-700" : "border-slate-800"}`}
-            onClick={() => setMode("signin")}
-            data-testid="button-mode-signin"
-          >
-            Sign in
-          </button>
-          <button
-            className={`px-3 py-2 rounded-xl border ${mode === "signup" ? "bg-slate-800 border-slate-700" : "border-slate-800"}`}
-            onClick={() => setMode("signup")}
-            data-testid="button-mode-signup"
-          >
-            Sign up
-          </button>
-        </div>
+          <div className="teaim-toggle" role="tablist" aria-label="Choose sign in method">
+            <button
+              type="button"
+              className="text-sm"
+              data-active={mode === "signin"}
+              onClick={() => setMode("signin")}
+              data-testid="button-mode-signin"
+            >
+              Sign in
+            </button>
+            <button
+              type="button"
+              className="text-sm"
+              data-active={mode === "signup"}
+              onClick={() => setMode("signup")}
+              data-testid="button-mode-signup"
+            >
+              Sign up
+            </button>
+          </div>
 
-        <div className="space-y-2">
-          <input
-            className="w-full border rounded-xl px-3 py-2 bg-slate-950/60 border-slate-800"
-            placeholder="email@company.com"
-            value={email}
-            onChange={e => setEmail(e.target.value)}
-            data-testid="input-email"
-          />
-          <input
-            className="w-full border rounded-xl px-3 py-2 bg-slate-950/60 border-slate-800"
-            placeholder="password (optional)"
-            type="password"
-            value={pass}
-            onChange={e => setPass(e.target.value)}
-            data-testid="input-password"
-          />
-        </div>
+          <div className="space-y-3">
+            <input
+              className="teaim-input w-full"
+              placeholder="you@company.com"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              data-testid="input-email"
+            />
+            <input
+              className="teaim-input w-full"
+              placeholder="Password (optional)"
+              type="password"
+              value={pass}
+              onChange={e => setPass(e.target.value)}
+              data-testid="input-password"
+            />
+          </div>
 
-        <div className="flex gap-2">
-          <button
-            className="flex-1 px-3 py-2 rounded-xl bg-indigo-600 hover:bg-indigo-500"
-            onClick={password}
-            data-testid="button-password-auth"
-          >
-            {mode === "signin" ? "Sign in" : "Create account"}
-          </button>
-          <button
-            className="flex-1 px-3 py-2 rounded-xl border border-slate-700 hover:bg-slate-800"
-            onClick={magic}
-            data-testid="button-magic-link"
-          >
-            Email me a link
-          </button>
-        </div>
+          <div className="space-y-3">
+            <button
+              className="teaim-cta w-full justify-center"
+              onClick={password}
+              data-testid="button-password-auth"
+            >
+              {mode === "signin" ? "Sign in" : "Create account"}
+            </button>
+            <button
+              className="teaim-cta-ghost w-full justify-center"
+              onClick={magic}
+              data-testid="button-magic-link"
+            >
+              Email me a link
+            </button>
+          </div>
 
-        {msg && <div className="text-xs opacity-70" data-testid="text-message">{msg}</div>}
+          {msg && <div className="text-xs text-muted-foreground" data-testid="text-message">{msg}</div>}
+          <p className="text-center text-xs text-muted-foreground">
+            Need help? <a className="font-medium text-[var(--accent)]" href="mailto:info@teaim.app">info@teaim.app</a>
+          </p>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- refresh the public landing hero with branded gradients, logo placement, animated copy, and updated calls to action that direct visitors into beta and contact flows
- restyle the authentication screen with the new TEAIM surface treatment, logo, segmented toggle, and gradient buttons for password and magic-link flows
- extend the shared theme tokens with light/dark brand palettes, gradient utilities, CTA styles, and add updated meta tags to advertise the new "TEAIM — AI in Your Team. Power in Your Project." headline

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e558c01480832988364a97fb68b520